### PR TITLE
Handle BitBucket in manifest

### DIFF
--- a/pb_git/cmds.py
+++ b/pb_git/cmds.py
@@ -222,6 +222,42 @@ def getgithubname(remote):
             githubname, remote))
     return githubname
 
+def get_view_url_github(url, sha1):
+    """
+    >>> get_view_url_github('git://github.com/PacBio/Bar', 'abcde')
+    'https://github.com/PacBio/Bar/tree/abcde'
+    """
+    githubname = getgithubname(url)
+    view_url = 'https://github.com/%s/tree/%s' %(
+        githubname, sha1)
+    return view_url
+
+def get_bitbucket_project_and_repo(remote):
+    """
+    >>> get_bitbucket_project_and_repo('ssh://git@bitbucket.nanofluidics.com:7999/sat/bam2fastx.git')
+    ['sat', 'bam2fastx']
+    """
+    re_remote = re.compile(r'bitbucket[^/]*/(.*)')
+    projreponame = re_remote.search(remote).group(1)
+    if projreponame.endswith('.git'):
+        projreponame = projreponame[:-4]
+    return projreponame.split('/')
+
+def get_view_url_bitbucket(url, sha1):
+    """
+    >>> get_view_url_bitbucket('ssh://git@bitbucket.nanofluidics.com:7999/sat/bam2fastx.git', 'abcde')
+    'http://bitbucket.nanofluidics.com:7990/projects/sat/repos/bam2fastx/browse?at=abcde'
+    """
+    project, repo = get_bitbucket_project_and_repo(url)
+    view_url = 'http://bitbucket.nanofluidics.com:7990/projects/{project}/repos/{repo}/browse?at={sha1}'.format(**locals())
+    return view_url
+
+def get_view_url(url, sha1):
+    if 'bitbucket' in url:
+        return get_view_url_bitbucket(url, sha1)
+    else:
+        return get_view_url_github(url, sha1)
+
 def indented_list(vals, indent):
     return indent + '[\n' + indent*2 + '"' + ('",\n' + indent*2 + '"').join(vals) + '"\n' + indent + ']'
 
@@ -230,9 +266,7 @@ def manifest(cfgs):
     for cfg in cfgs:
         sha1 = cfg['sha1']
         url = cfg['url']
-        githubname = getgithubname(url)
-        view_url = 'https://github.com/%s/tree/%s' %(
-            githubname, sha1)
+        view_url = get_view_url(url, sha1)
         tree.append(view_url)
     tree.sort()
     return indented_list(tree, '    ')


### PR DESCRIPTION
@armintoepfer, any objection?

`getgithubname()` was actually an implementation detail. It's used only for the manifest, which now has a bit less value because of the internal GitHub hosting. Oh, well.
```sh
$ make test
nosetests -v --with-doctest pb_git/cmds.py
Doctest: pb_git.cmds.get_bitbucket_project_and_repo ... ok
Doctest: pb_git.cmds.get_view_url_bitbucket ... ok
Doctest: pb_git.cmds.get_view_url_github ... ok
Doctest: pb_git.cmds.getgithubname ... ok

----------------------------------------------------------------------
Ran 4 tests in 0.007s
```