### PR TITLE
Fix submodule

### DIFF
--- a/pb_git/cmds.py
+++ b/pb_git/cmds.py
@@ -328,7 +328,13 @@ def _checkout_repo(conf, mirrors_base):
 
 def update_submodules(path):
     cmd = 'git -C {} submodule update --init --remote --recursive'.format(path)
-    system(cmd)
+    try:
+        system(cmd)
+    except Exception:
+        log.exception("We will remove all submodules and retry.")
+        system('git -C {} submodule deinit -f .'.format(path))
+        system('rm -rf {}/.git/modules'.format(path))
+        system(cmd)
 
 def checkout_repo(conf, mirrors_base):
     _checkout_repo(conf, mirrors_base)

--- a/pb_git/cmds.py
+++ b/pb_git/cmds.py
@@ -327,7 +327,7 @@ def _checkout_repo(conf, mirrors_base):
         checkout_repo_from_url(url, sha1, 'origin', path)
 
 def update_submodules(path):
-    cmd = 'git -C {} submodule update --init --remote --recursive --depth 1'.format(path)
+    cmd = 'git -C {} submodule update --init --remote --recursive'.format(path)
     system(cmd)
 
 def checkout_repo(conf, mirrors_base):


### PR DESCRIPTION
* https://jira.pacificbiosciences.com/browse/DEP-69

Now:
```sh
[SYS](/home/UNIXHOME/cdunn/repo/pb/pf/smrtanalysis/bioinformatics/ext/bin/pb-git/pb_git/cmds.py:51)
        git -C unanimity submodule update --init --remote --recursive
fatal: Needed a single revision
Unable to find current origin/pb revision in submodule path 'third-party/htslib'
[ERROR](/home/UNIXHOME/cdunn/repo/pb/pf/smrtanalysis/bioinformatics/ext/bin/pb-git/pb_git/cmds.py:334)
        We will remove all submodules and retry.
Traceback (most recent call last):
  File "/home/UNIXHOME/cdunn/repo/pb/pf/smrtanalysis/bioinformatics/ext/bin/pb-git/pb_git/cmds.py", line 332, in update_submodules
    system(cmd)
  File "/home/UNIXHOME/cdunn/repo/pb/pf/smrtanalysis/bioinformatics/ext/bin/pb-git/pb_git/cmds.py", line 54, in system
    raise IOError('{rc} <- {call!r}'.format(rc=rc, call=call))
IOError: 256 <- 'git -C unanimity submodule update --init --remote --recursive'
[SYS](/home/UNIXHOME/cdunn/repo/pb/pf/smrtanalysis/bioinformatics/ext/bin/pb-git/pb_git/cmds.py:51)
        git -C unanimity submodule deinit -f .
Cleared directory 'third-party/htslib'
Submodule 'third-party/htslib' (ssh://git@bitbucket.nanofluidics.com:7999/sat/htslib.git) unregistered for path 'third-party/htslib'
Cleared directory 'third-party/pbbam'
Submodule 'third-party/pbbam' (ssh://git@bitbucket.nanofluidics.com:7999/sat/pbbam.git) unregistered for path 'third-party/pbbam'
Cleared directory 'third-party/pbcopper'
Submodule 'third-party/pbcopper' (ssh://git@bitbucket.nanofluidics.com:7999/sat/pbcopper.git) unregistered for path 'third-party/pbcopper'
Cleared directory 'third-party/seqan'
Submodule 'third-party/seqan' (ssh://git@bitbucket.nanofluidics.com:7999/sat/seqan.git) unregistered for path 'third-party/seqan'
[SYS](/home/UNIXHOME/cdunn/repo/pb/pf/smrtanalysis/bioinformatics/ext/bin/pb-git/pb_git/cmds.py:51)
        rm -rf unanimity/.git/modules
[SYS](/home/UNIXHOME/cdunn/repo/pb/pf/smrtanalysis/bioinformatics/ext/bin/pb-git/pb_git/cmds.py:51)
        git -C unanimity submodule update --init --remote --recursive
Submodule 'third-party/htslib' (ssh://git@bitbucket.nanofluidics.com:7999/sat/htslib.git) registered for path 'third-party/htslib'
Submodule 'third-party/pbbam' (ssh://git@bitbucket.nanofluidics.com:7999/sat/pbbam.git) registered for path 'third-party/pbbam'
Submodule 'third-party/pbcopper' (ssh://git@bitbucket.nanofluidics.com:7999/sat/pbcopper.git) registered for path 'third-party/pbcopper'
Submodule 'third-party/seqan' (ssh://git@bitbucket.nanofluidics.com:7999/sat/seqan.git) registered for path 'third-party/seqan'
Cloning into 'third-party/htslib'...
remote: Counting objects: 5311, done.
remote: Compressing objects: 100% (1809/1809), done.
remote: Total 5311 (delta 3437), reused 5311 (delta 3437)
Receiving objects: 100% (5311/5311), 4.04 MiB | 1.51 MiB/s, done.
Resolving deltas: 100% (3437/3437), done.
Checking connectivity... done.
Submodule path 'third-party/htslib': checked out '6b6c81388e699c0c0cf2d1f7fe59c5da60fb7b9a'
Cloning into 'third-party/pbbam'...
remote: Counting objects: 1167, done.
remote: Compressing objects: 100% (386/386), done.
remote: Total 1167 (delta 777), reused 1125 (delta 753)
Receiving objects: 100% (1167/1167), 7.24 MiB | 3.66 MiB/s, done.
Resolving deltas: 100% (777/777), done.
Checking connectivity... done.
```